### PR TITLE
Feat/custom_nat_gateway_configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform module which creates network, subnets, and few peerings resources on G
 
 ## Examples
 
-- [Example of minimal network configuration use case](examples/basic/main.tf)
+- [Example of basic network configuration use case](examples/basic/main.tf)
 - [Example of network for GKE use case](examples/gke/main.tf)
 
 <!-- BEGIN_TF_DOCS -->
@@ -12,16 +12,17 @@ Terraform module which creates network, subnets, and few peerings resources on G
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | 5.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | 5.2.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_gcp_peering_cidr"></a> [gcp\_peering\_cidr](#input\_gcp\_peering\_cidr) | CIDR to reserve for GCP service in this VPC | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The name of the network being created | `any` | n/a | yes |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where this VPC will be created | `any` | n/a | yes |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | The list of subnets beeing created | <pre>object({<br>    name            = string<br>    region          = string<br>    primary_cidr    = string<br>    serverless_cidr = string<br>    secondary_ranges = map(object({<br>      name = string<br>      cidr = string<br>    }))<br>  })</pre> | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the network being created | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where this VPC will be created | `string` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | The list of subnets beeing created | <pre>map(object({<br>    name            = string<br>    region          = string<br>    primary_cidr    = string<br>    serverless_cidr = string<br>    secondary_ranges = map(object({<br>      name = string<br>      cidr = string<br>    }))<br>  }))</pre> | n/a | yes |
+| <a name="input_nats"></a> [nats](#input\_nats) | Custom configuration for nat gateways. The map key must be the nat region and there must be a subnet in that region. Possible values for mode are `ENDPOINT_INDEPENDANT_MAPPING`, `DYNAMIC_PORT_ALLOCATION` or `NONE`. | <pre>map(object({<br>    mode      = optional(string, "ENDPOINT_INDEPENDANT_MAPPING")<br>    min_ports = optional(number, 64)<br>    max_ports = optional(number, null)<br>  }))</pre> | `{}` | no |
 | <a name="input_routing_mode"></a> [routing\_mode](#input\_routing\_mode) | The network routing mode (default 'GLOBAL'). | `string` | `"GLOBAL"` | no |
 
 ## Outputs

--- a/docs/usage/basic.md
+++ b/docs/usage/basic.md
@@ -2,7 +2,7 @@
 
 ## Specifications
 
-- 2 Subnets in 2 different region
+- 3 Subnets in 3 different region with different NAT gateways
 - Serverless Connector in EU
 - Peering with Google
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,15 +2,34 @@ module "basic" {
   source = "../.."
 
   name       = "testing"
-  project_id = "library-344516"
+  project_id = "padok-library-gcp-host"
+
+  nats = {
+    "europe-west1" = {
+      mode      = "DYNAMIC_PORT_ALLOCATION"
+      min_ports = 64
+      max_ports = 2048
+    }
+    "europe-west2" = {
+      min_ports = 1024
+    }
+  }
+
   subnets = {
-    "eu" = {
-      name             = "eu"
+    "eu-1" = {
+      name             = "eu-1"
       region           = "europe-west1"
+      primary_cidr     = "172.16.0.0/20"
+      serverless_cidr  = ""
+      secondary_ranges = {}
+    },
+    "eu-2" = {
+      name             = "eu-2"
+      region           = "europe-west2"
       primary_cidr     = "172.16.48.0/20"
       serverless_cidr  = "172.16.80.0/28"
       secondary_ranges = {}
-    },
+    }
     "us" = {
       name             = "us"
       region           = "northamerica-northeast1"

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.21"
+      version = "~> 4.49"
     }
   }
 }

--- a/examples/gke/main.tf
+++ b/examples/gke/main.tf
@@ -3,12 +3,13 @@ module "gke" {
 
   name       = "testing"
   project_id = "library-344516"
+
   subnets = {
     "eu" = {
-      name             = "eu"
-      region           = "europe-west1"
-      primary_cidr     = "172.16.48.0/20"
-      serverless_cidr  = ""
+      name            = "eu"
+      region          = "europe-west1"
+      primary_cidr    = "172.16.48.0/20"
+      serverless_cidr = ""
       secondary_ranges = {
         pods = {
           name = "gke-pods-main"

--- a/examples/gke/versions.tf
+++ b/examples/gke/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.21"
+      version = "~> 4.49"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 locals {
   # Regions list
-  regions = flatten([
+  regions = toset(flatten([
     for subnet in var.subnets : [
       subnet.region
     ]
-  ])
+  ]))
 
   # VPC Access Connectors map
   vpc_access_connectors = {
@@ -59,7 +59,7 @@ module "vpc" {
 #
 
 resource "google_compute_router" "router" {
-  for_each = toset(local.regions)
+  for_each = local.regions
 
   project = var.project_id
   region  = each.key
@@ -74,7 +74,7 @@ resource "google_compute_router" "router" {
 #
 
 resource "google_compute_address" "ip" {
-  for_each = toset(local.regions)
+  for_each = local.regions
 
   project = var.project_id
   region  = each.key
@@ -86,7 +86,7 @@ resource "google_compute_address" "ip" {
 }
 
 resource "google_compute_router_nat" "nat" {
-  for_each = toset(local.regions)
+  for_each = local.nats
 
   project = var.project_id
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "nats" {
     max_ports = optional(number, null)
   }))
   default     = {}
-  description = "Custom configuration for nat gateways. The map key must be the nat region and there must be a subnet in that region."
+  description = "Custom configuration for nat gateways. The map key must be the nat region and there must be a subnet in that region. Possible values for mode are `ENDPOINT_INDEPENDANT_MAPPING`, `DYNAMIC_PORT_ALLOCATION` or `NONE`."
 
   validation {
     condition     = alltrue([for nat in var.nats : contains(["DYNAMIC_PORT_ALLOCATION", "ENDPOINT_INDEPENDANT_MAPPING", "NONE"], nat.mode)])

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "project_id" {
-  type = string
+  type        = string
   description = "The ID of the project where this VPC will be created"
 }
 
 variable "name" {
-  type = string
+  type        = string
   description = "The name of the network being created"
 }
 
@@ -26,6 +26,21 @@ variable "subnets" {
     }))
   }))
   description = "The list of subnets beeing created"
+}
+
+variable "nats" {
+  type = map(object({
+    mode      = optional(string, "ENDPOINT_INDEPENDANT_MAPPING")
+    min_ports = optional(number, 64)
+    max_ports = optional(number, null)
+  }))
+  default     = {}
+  description = "Custom configuration for nat gateways. The map key must be the nat region and there must be a subnet in that region."
+
+  validation {
+    condition     = alltrue([for nat in var.nats : contains(["DYNAMIC_PORT_ALLOCATION", "ENDPOINT_INDEPENDANT_MAPPING", "NONE"], nat.mode)])
+    error_message = "Nat mode must either be ENDPOINT_INDEPENDANT_MAPPING, DYNAMIC_PORT_ALLOCATION or NONE"
+  }
 }
 
 variable "gcp_peering_cidr" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.21"
+      version = "~> 4.49"
     }
   }
 }


### PR DESCRIPTION
Fixes #33 
Custom configuration can be added for nat gateways. Only one gateway per region can be created by the module, so the configuration depends on the region.

Possible improvement could be to allow putting different nat gateways with varying configuration in the same region.

The default behaviour was not modified, so existing uses of this module will work the same.